### PR TITLE
Move rescript-zora to bs-dev-dependencies

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -16,7 +16,9 @@
     { "dir": "tests", "subdirs": true, "type": "dev" }
   ],
   "bs-dependencies": [
-    "@dusty-phillips/rescript-zora",
     "@ryyppy/rescript-promise"
+  ],
+  "bs-dev-dependencies": [
+    "@dusty-phillips/rescript-zora"
   ]
 }


### PR DESCRIPTION
This change prevents this issue:

  Error: package @dusty-phillips/rescript-zora not found or built