### PR TITLE
Feat: adds Table.toArray function

### DIFF
--- a/src/Table.mjs
+++ b/src/Table.mjs
@@ -45,6 +45,9 @@ function MakeTable(Schema) {
   var where = function (dexie, fieldName) {
     return dexie.table(Schema.tableName).where(fieldName);
   };
+  var toArray = function (dexie) {
+    return dexie.table(Schema.tableName).toArray();
+  };
   return {
           add: add,
           bulkAdd: bulkAdd,
@@ -58,7 +61,8 @@ function MakeTable(Schema) {
           getByCriteria: getByCriteria,
           put: put,
           update: update,
-          where: where
+          where: where,
+          toArray: toArray
         };
 }
 

--- a/src/Table.res
+++ b/src/Table.res
@@ -23,6 +23,7 @@ module type MakeTableType = (Schema: SchemaItem) =>
   let put: (Database.t, t) => Promise.t<id>
   let update: (Database.t, id, Js.t<'a>) => Promise.t<int>
   let where: (Database.t, string) => Where.t<t>
+  let toArray: Database.t => Promise.t<array<t>>
 }
 
 module MakeTable: MakeTableType = (Schema: SchemaItem) => {
@@ -60,6 +61,8 @@ module MakeTable: MakeTableType = (Schema: SchemaItem) => {
     external update: (table, id, Js.t<'a>) => Promise.t<int> = "update"
     @send
     external where: (table, string) => Where.t<t> = "where"
+    @send
+    external toArray: table => Promise.t<array<t>> = "toArray"
   }
 
   let add = (dexie: Database.t, item: t): Promise.t<id> => {
@@ -102,5 +105,8 @@ module MakeTable: MakeTableType = (Schema: SchemaItem) => {
   }
   let where = (dexie: Database.t, fieldName: string): Where.t<t> => {
     dexie->Bindings.table(Schema.tableName)->Bindings.where(fieldName)
+  }
+  let toArray = (dexie: Database.t): Promise.t<array<t>> => {
+    dexie->Bindings.table(Schema.tableName)->Bindings.toArray
   }
 }

--- a/tests/TestTable.test.mjs
+++ b/tests/TestTable.test.mjs
@@ -180,6 +180,36 @@ Zora$1.test("Table commands", (function (t) {
                               
                             }));
               }));
+        t.test("Test toArray method", (function (t) {
+                var dexie = TestSetup$Dexie.setup(undefined);
+                var friends = [
+                  {
+                    id: 1,
+                    name: "Chris",
+                    color: "Purple"
+                  },
+                  {
+                    id: 2,
+                    name: "Samuel",
+                    color: "Blue"
+                  },
+                  {
+                    id: 3,
+                    name: "Samantha",
+                    color: "Red"
+                  }
+                ];
+                return TestSetup$Dexie.p(TestSetup$Dexie.p(Curry._2(TestSetup$Dexie.Friend.bulkAdd, dexie, friends), (function (param) {
+                                  return Curry._1(TestSetup$Dexie.Friend.toArray, dexie);
+                                })), (function (result) {
+                              t.equal(result, friends, "Should list all friends");
+                              return Curry._2(TestSetup$Dexie.Friend.bulkDelete, dexie, [
+                                          1,
+                                          2,
+                                          3
+                                        ]);
+                            }));
+              }));
         return Zora.done(undefined);
       }));
 

--- a/tests/TestTable.test.res
+++ b/tests/TestTable.test.res
@@ -147,5 +147,28 @@ zora("Table commands", t => {
     })
   })
 
+  t->test("Test toArray method", t => {
+    let dexie = setup()
+
+    open TestSetup.FriendSchema
+
+    let friends = [
+      {id: Some(1), name: "Chris", color: #Purple},
+      {id: Some(2), name: "Samuel", color: #Blue},
+      {id: Some(3), name: "Samantha", color: #Red},
+    ]
+
+    dexie
+    ->Friend.bulkAdd(friends)
+    ->p(_ => {
+      dexie->Friend.toArray
+    })
+    ->p(result => {
+      t->equal(result, friends, "Should list all friends")
+
+      dexie->Friend.bulkDelete([1, 2, 3])
+    })
+  })
+
   done()
 })

--- a/tests/TestWhere.test.mjs
+++ b/tests/TestWhere.test.mjs
@@ -211,7 +211,6 @@ Zora$1.test("Where clauses", (function (t) {
                                                       ]
                                                     ]).toArray();
                                       })), (function (items) {
-                                    console.log(items);
                                     t.equal(items, [
                                           {
                                             id: 2,

--- a/tests/TestWhere.test.res
+++ b/tests/TestWhere.test.res
@@ -132,7 +132,6 @@ zora("Where clauses", t => {
       ->Collection.toArray
     })
     ->p(items => {
-      Js.log(items)
       t->equal(
         items,
         [


### PR DESCRIPTION
This PR adds a binding for the [Table.toArray](https://dexie.org/docs/Table/Table.toArray()) method.
This is quite useful for fetching the whole table items, which is something we are needing for a current project in which we are using `rescript-dexie`.