### PR TITLE
Add binding proposals for event "on" functions

### DIFF
--- a/src/Database.res
+++ b/src/Database.res
@@ -1,5 +1,7 @@
 type t
 
+type event = {newVersion: string}
+
 @new @module("dexie") external make: string => t = "default"
 
 @send external opendb: t => promise<unit> = "open"
@@ -14,3 +16,11 @@ external transaction: (
 ) => promise<'result> = "transaction"
 
 @send external version: (t, int) => Version.t = "version"
+
+@send external on: (t, [#blocked | #close | #ready], unit => unit) => unit = "on"
+
+@send external on1: (t, [#ready], unit => promise<'a>) => unit = "on"
+
+@send external on2: (t, [#populate], Transaction.t => promise<'a>) => unit = "on"
+
+@send external on3: (t, [#versionchange], event => bool) => unit = "on"


### PR DESCRIPTION
This is more of a proposal than a completely new functionality.
This library is missing the "on..." event functions. I tried to implement bindings for the most important ones based on what I could decipher from documentation (the callback functions are documented rather vaguely). In my project I used the "populate" and "ready" and both worked correctly. In this project I did not yet implement any tests because first I'd like to know your opinion. For example I'm struggling with naming these functions.